### PR TITLE
fix: Support SSSS 16 correctly in lj92.

### DIFF
--- a/lj92.c
+++ b/lj92.c
@@ -402,12 +402,13 @@ inline static int nextdiff(ljp* self, int component_idx, int Px) {
 
     u16 ssssused = self->hufflut[component_idx][index];
     int usedbits = ssssused & 0xFF;
-    int t = ssssused >> 8;
-    self->sssshist[t]++;
+    int ssss = ssssused >> 8;
+    int extra_bits = ssss % 16;
+    self->sssshist[ssss]++;
     cnt -= usedbits;
     int keepbitsmask = (1 << cnt) - 1;
     b &= keepbitsmask;
-    while (cnt < t) {
+    while (cnt < extra_bits) {
         next = *(u16*)&self->data[ix];
         int one = next & 0xFF;
         int two = next >> 8;
@@ -420,12 +421,17 @@ inline static int nextdiff(ljp* self, int component_idx, int Px) {
         } else if (two == 0xFF)
             ix++;
     }
-    cnt -= t;
-    int diff = b >> cnt;
-    int vt = 1 << (t - 1);
-    if (diff < vt) {
-        vt = (-1 << t) + 1;
+    cnt -= extra_bits;
+    int diff;
+    if (ssss == 16) {
+      diff = 32768;
+    } else {
+      diff = b >> cnt;
+      int vt = 1 << (extra_bits - 1);
+      if (diff < vt) {
+        vt = (0xffffffff << extra_bits) + 1;
         diff += vt;
+      }
     }
     keepbitsmask = (1 << cnt) - 1;
     self->b = b & keepbitsmask;


### PR DESCRIPTION
As explained [here](https://www.w3.org/Graphics/JPEG/itu-t81.pdf) in section H.1.2.2 on page 134, the correct number of extra bits for SSSS 16 is 0 because the difference value is always 32768.  The lj92 code was assuming that SSSS is always equal to the number of extra bits and then doing some math using the pattern that appears in the first 16 elements, extending that pattern to SSSS 16.  That is the wrong thing to do.

The solution is to recognize that the number of extra bits is not necessarily the same as the SSSS and then put in a special case for SSSS 16.